### PR TITLE
Update PacklinkPrestaShopUtility.php

### DIFF
--- a/src/classes/Utility/PacklinkPrestaShopUtility.php
+++ b/src/classes/Utility/PacklinkPrestaShopUtility.php
@@ -99,7 +99,8 @@ class PacklinkPrestaShopUtility
     public static function dieJson(array $data = array())
     {
         header('Content-Type: application/json');
-
+        header('Cache-Control: no-store, no-cache, must-revalidate');
+        header('Pragma: no-cache');
         die(json_encode($data));
     }
 


### PR DESCRIPTION
fix(ajax): send no-cache headers on JSON responses

Add Cache-Control and Pragma no-cache headers in dieJson() so Packlink AJAX responses are never cached.

The draft-status endpoint (OrderDraft::getDraftStatus) returns JSON with only a Content-Type header. Without cache-control headers, a GET response can be served stale by the browser or an intermediate cache. As a result the order panel kept showing "Draft is currently being created" even after the shipment draft had actually been created on Packlink's side.

Forcing no-store/no-cache on all dieJson() responses makes the status poll always reflect the real state.