### PR TITLE
Update BaseRepository.php

### DIFF
--- a/src/classes/Repositories/BaseRepository.php
+++ b/src/classes/Repositories/BaseRepository.php
@@ -390,7 +390,7 @@ class BaseRepository implements RepositoryInterface
             ->where($condition);
         $this->applyLimitAndOrderBy($query, $filter);
 
-        $result = \Db::getInstance()->executeS($query);
+        $result = \Db::getInstance()->executeS($query, true, false);
 
         return !empty($result) ? $result : array();
     }


### PR DESCRIPTION
fix(repository): disable SQL query cache on entity reads

Pass $use_cache = false to executeS() in getRecordsByCondition() so Packlink entity rows (packlink_entity) are always read fresh.

PrestaShop's executeS($sql, $array = true, $use_cache = true) caches SELECT results (Memcached). During task-runner wakeup, a single request writes an empty runner status to release the lock (A) and then reads it back (B). With caching on, (B) returned the stale cached status instead of the value just written in (A), so the runner could never reset its own lock — causing a permanent deadlock and shipment drafts stuck at "Draft is currently being created".

Reading without cache makes the runner status reflect the real DB state and unblocks draft creation.