### PR TITLE
Update QueueItemRepository.php

### DIFF
--- a/src/classes/Repositories/QueueItemRepository.php
+++ b/src/classes/Repositories/QueueItemRepository.php
@@ -214,7 +214,7 @@ class QueueItemRepository extends BaseRepository implements QueueItemRepositoryI
                 . ' INNER JOIN ' . bqSQL(_DB_PREFIX_ . static::TABLE_NAME) . ' AS queueTable'
                 . ' ON queueView.id = queueTable.id';
 
-            $records = \Db::getInstance()->executeS($query);
+            $records = \Db::getInstance()->executeS($query, true, false);
             $queuedItems = $this->unserializeEntities($records);
         } catch (\PrestaShopDatabaseException $exception) {
             // In case of exception return empty result set


### PR DESCRIPTION
fix(queue): disable SQL cache when reading queued items

QueueItemRepository::findOldestQueuedItems() read the queue with executeS() and the default $use_cache = true. The query uses a nested subquery with an alias, which PrestaShop's cache invalidation does not always associate with the queue table, so the cached result was never purged when new tasks were enqueued.

As a result the task runner read a stale queue snapshot from Memcached and did not see newly enqueued SendDraftTask items, so shipment drafts for new orders stayed pending until the queue was read fresh (e.g. from the module config page).

Reading without cache makes the runner always see freshly enqueued tasks.